### PR TITLE
Start documentation of common test failures

### DIFF
--- a/docs/common_test_failures/README.md
+++ b/docs/common_test_failures/README.md
@@ -1,0 +1,6 @@
+# Common test failures
+
+The documents in this folder are intended to be used to help root-cause common test failures, especially in cases where the underlying cause of the failure may not be immediately obvious from the test step or expected outcomes.
+
+The test cases listed in these files are not an exhaustive list and this folder is intended to act as a growing repository.
+

--- a/docs/common_test_failures/README.md
+++ b/docs/common_test_failures/README.md
@@ -1,6 +1,7 @@
 # Common test failures
 
-The documents in this folder are intended to be used to help root-cause common test failures, especially in cases where the underlying cause of the failure may not be immediately obvious from the test step or expected outcomes.
+The documents in this folder are intended to be used to help root-cause common test failures,
+especially in cases where the underlying cause of the failure may not be immediately obvious from the test step or expected outcomes.
 
 The test cases listed in these files are not an exhaustive list and this folder is intended to act as a growing repository.
 

--- a/docs/common_test_failures/TC-DA-1.7.md
+++ b/docs/common_test_failures/TC-DA-1.7.md
@@ -27,7 +27,7 @@ This test verifies that the DUTs are correctly following all the requirements fo
   <tr>
    <td>Found matching public keys in different DUTs
    </td>
-   <td>The two devices under test use the same DAC public key (aka, they are the same DAC). This is disallowed under section 6.2.2, which states “All commissionable Matter Nodes SHALL include a Device Attestation Certificate (DAC) and corresponding private key, unique to that Device.” \
+   <td>The two devices under test use the same DAC public key (aka, they are the same DAC). This is disallowed under section 6.2.2, which states “All commissionable Matter Nodes SHALL include a Device Attestation Certificate (DAC) and corresponding private key, unique to that Device.
 Either this means the company has used a single DAC for all its products, or they’ve attempted to run this two-DUT test against a single DUT.
    </td>
   </tr>

--- a/docs/common_test_failures/TC-DA-1.7.md
+++ b/docs/common_test_failures/TC-DA-1.7.md
@@ -1,0 +1,47 @@
+
+
+## TC-DA-1.7
+
+This test verifies that the DUTs are correctly following all the requirements for the Device Attestation certificate chain. 
+
+
+<table>
+  <tr>
+   <td><strong>Error text</strong>
+   </td>
+   <td><strong>Probable root cause</strong>
+   </td>
+  </tr>
+  <tr>
+   <td>Re-raising error and failing: found new invalid PAA: {filename}
+   </td>
+   <td>The PAA list that was specified for this test contains at least one invalid certificate. Check that all the files in the given directory are valid PAAs in DER format.
+   </td>
+  </tr>
+  <tr>
+   <td>This test requires 2 DUTs
+   </td>
+   <td>Two DUTs are used for this test because we need to verify that the DACs are provisioned per individual unit. This needs to be specified on the command line using <code>--dut-node-id nodeid1 nodeid2</code> (for commissioned nodes).  
+   </td>
+  </tr>
+  <tr>
+   <td>Found matching public keys in different DUTs
+   </td>
+   <td>The two devices under test use the same DAC public key (aka, they are the same DAC). This is disallowed under section 6.2.2, which states “All commissionable Matter Nodes SHALL include a Device Attestation Certificate (DAC) and corresponding private key, unique to that Device.” \
+Either this means the company has used a single DAC for all its products, or they’ve attempted to run this two-DUT test against a single DUT.
+   </td>
+  </tr>
+  <tr>
+   <td>DUT %d PAI (%s) not matched in PAA trust store
+   </td>
+   <td>The PAI does not chain up to a PAA in the given PAA directory. Verify the expected PAA and confirm that it is present in the DCL.
+   </td>
+  </tr>
+  <tr>
+   <td>PAI AKID must not be in denylist
+   </td>
+   <td>The PAI chains up to a well known test PAA. Translation: This DUT is using a test DAC from the SDK. This test must be run against production certificates.
+   </td>
+  </tr>
+</table>
+

--- a/docs/common_test_failures/TC-RR-1.1.md
+++ b/docs/common_test_failures/TC-RR-1.1.md
@@ -1,0 +1,6 @@
+## TC-RR-1.1 
+
+TC-RR-1.1 is a stress test of the DUT, where it attempts to verify that the DUT meets all the specification required minimums, and can handle having its variable length attributes filled completely to their stated supported sizes at the same time. This includes the fabric table, the group key table, groups clusters, labels, ACLs, subscriptions, CASE sessions, read paths etc.
+
+This test is run on every push to the CI. It is verified to work on all-clusters, so the SDK implementation is correct. However, this is a stress test. Any failure in this test is most likely an indication of a real failure on the DUT either stemming from heap exhaustion or some kind of buffer starvation. 
+


### PR DESCRIPTION
Per a request from an ATL, this is the start of an ongoing documentation project to help ATLs and companies root cause common test failure problems that are real failures.