### PR TITLE
Add await to async function

### DIFF
--- a/onboarding_payload_test_suite/onboarding_script_support.py
+++ b/onboarding_payload_test_suite/onboarding_script_support.py
@@ -118,7 +118,7 @@ class PayloadParsingTestBaseClass(TestCase, UserPromptSupport, object):
             raise PayloadParsingError(
                 f"Error decoding onboarding payload. Error {error}"
             )
-        chip_tool.destroy_device()
+        await chip_tool.destroy_device()
         return parsed_payload
 
     def create_onboarding_code_payload_prompt(self, code_type: str) -> PromptRequest:


### PR DESCRIPTION
The `destroy_device` method is being updated in the following PR to become `async`, so the function call should be called using `await`.
- PR: https://github.com/project-chip/certification-tool-backend/pull/29