### PR TITLE
TC-DD-1.3 script clarification update

### DIFF
--- a/onboarding_payload_test_suite/onboarding_script_support.py
+++ b/onboarding_payload_test_suite/onboarding_script_support.py
@@ -172,7 +172,7 @@ class PayloadParsingTestBaseClass(TestCase, UserPromptSupport, object):
         logger.info("Verified QR code payload version: {bin(version)}")
 
     def payload_rendezvous_capabilities_bit_mask_check(
-        self, discovery_capabilities_bitmask: int, max_bit: int
+        self, discovery_capabilities_bitmask: int
     ) -> None:
         DISCOVERY_CAP_BLE = (1 << 1)
         DISCOVERY_CAP_IP = (1 << 2)

--- a/onboarding_payload_test_suite/onboarding_script_support.py
+++ b/onboarding_payload_test_suite/onboarding_script_support.py
@@ -177,6 +177,7 @@ class PayloadParsingTestBaseClass(TestCase, UserPromptSupport, object):
         DISCOVERY_CAP_BLE = 1 << 1
         DISCOVERY_CAP_IP = 1 << 2
         DISCOVERY_CAP_PAF = 1 << 3
+        DISCOVERY_CAP_NTL = 1 << 4
         ALL_CAPABILITIES_MASK = DISCOVERY_CAP_BLE | DISCOVERY_CAP_IP | DISCOVERY_CAP_PAF|DISCOVERY_CAP_NTL
         if ((discovery_capabilities_bitmask & ~ALL_CAPABILITIES_MASK) != 0) or (
             (discovery_capabilities_bitmask & ALL_CAPABILITIES_MASK) == 0

--- a/onboarding_payload_test_suite/onboarding_script_support.py
+++ b/onboarding_payload_test_suite/onboarding_script_support.py
@@ -172,9 +172,9 @@ class PayloadParsingTestBaseClass(TestCase, UserPromptSupport, object):
         logger.info("Verified QR code payload version: {bin(version)}")
 
     def payload_rendezvous_capabilities_bit_mask_check(
-        self, discovery_capabilities_bitmask: int
+        self, discovery_capabilities_bitmask: int, max_bit: int
     ) -> None:
-        if not (0 <= discovery_capabilities_bitmask <= 7):
+        if not (0 <= discovery_capabilities_bitmask <= max_bit):
             self.mark_step_failure(
                 f"""Invalid rendezvous capabilities bit mask,
                 detected value: {bin(discovery_capabilities_bitmask)}"""

--- a/onboarding_payload_test_suite/onboarding_script_support.py
+++ b/onboarding_payload_test_suite/onboarding_script_support.py
@@ -174,7 +174,11 @@ class PayloadParsingTestBaseClass(TestCase, UserPromptSupport, object):
     def payload_rendezvous_capabilities_bit_mask_check(
         self, discovery_capabilities_bitmask: int, max_bit: int
     ) -> None:
-        if not (0 <= discovery_capabilities_bitmask <= max_bit):
+        DISCOVERY_CAP_BLE = (1 << 1)
+        DISCOVERY_CAP_IP = (1 << 2)
+        DISCOVERY_CAP_PAF = (1 << 3)                
+        ALL_CAPABILITIES_MASK = DISCOVERY_CAP_BLE | DISCOVERY_CAP_IP | DISCOVERY_CAP_PAF
+        if ((discovery_capabilities_bitmask & ~ALL_CAPABILITIES_MASK) != 0) or ((discovery_capabilities_bitmask & ALL_CAPABILITIES_MASK) == 0):
             self.mark_step_failure(
                 f"""Invalid rendezvous capabilities bit mask,
                 detected value: {bin(discovery_capabilities_bitmask)}"""

--- a/onboarding_payload_test_suite/onboarding_script_support.py
+++ b/onboarding_payload_test_suite/onboarding_script_support.py
@@ -174,11 +174,13 @@ class PayloadParsingTestBaseClass(TestCase, UserPromptSupport, object):
     def payload_rendezvous_capabilities_bit_mask_check(
         self, discovery_capabilities_bitmask: int
     ) -> None:
-        DISCOVERY_CAP_BLE = (1 << 1)
-        DISCOVERY_CAP_IP = (1 << 2)
-        DISCOVERY_CAP_PAF = (1 << 3)                
+        DISCOVERY_CAP_BLE = 1 << 1
+        DISCOVERY_CAP_IP = 1 << 2
+        DISCOVERY_CAP_PAF = 1 << 3
         ALL_CAPABILITIES_MASK = DISCOVERY_CAP_BLE | DISCOVERY_CAP_IP | DISCOVERY_CAP_PAF
-        if ((discovery_capabilities_bitmask & ~ALL_CAPABILITIES_MASK) != 0) or ((discovery_capabilities_bitmask & ALL_CAPABILITIES_MASK) == 0):
+        if ((discovery_capabilities_bitmask & ~ALL_CAPABILITIES_MASK) != 0) or (
+            (discovery_capabilities_bitmask & ALL_CAPABILITIES_MASK) == 0
+        ):
             self.mark_step_failure(
                 f"""Invalid rendezvous capabilities bit mask,
                 detected value: {bin(discovery_capabilities_bitmask)}"""

--- a/onboarding_payload_test_suite/onboarding_script_support.py
+++ b/onboarding_payload_test_suite/onboarding_script_support.py
@@ -177,7 +177,7 @@ class PayloadParsingTestBaseClass(TestCase, UserPromptSupport, object):
         DISCOVERY_CAP_BLE = 1 << 1
         DISCOVERY_CAP_IP = 1 << 2
         DISCOVERY_CAP_PAF = 1 << 3
-        ALL_CAPABILITIES_MASK = DISCOVERY_CAP_BLE | DISCOVERY_CAP_IP | DISCOVERY_CAP_PAF
+        ALL_CAPABILITIES_MASK = DISCOVERY_CAP_BLE | DISCOVERY_CAP_IP | DISCOVERY_CAP_PAF|DISCOVERY_CAP_NTL
         if ((discovery_capabilities_bitmask & ~ALL_CAPABILITIES_MASK) != 0) or (
             (discovery_capabilities_bitmask & ALL_CAPABILITIES_MASK) == 0
         ):

--- a/onboarding_payload_test_suite/tcdd11/tcdd11.py
+++ b/onboarding_payload_test_suite/tcdd11/tcdd11.py
@@ -70,7 +70,7 @@ class TCDD11(PayloadParsingTestBaseClass):
         self.next_step()
         # Test step 2.b
         self.payload_rendezvous_capabilities_bit_mask_check(
-            qr_code_payload.rendezvousInfo
+            qr_code_payload.rendezvousInfo, 15
         )
         self.next_step()
         # Test step 2.c

--- a/onboarding_payload_test_suite/tcdd11/tcdd11.py
+++ b/onboarding_payload_test_suite/tcdd11/tcdd11.py
@@ -70,7 +70,7 @@ class TCDD11(PayloadParsingTestBaseClass):
         self.next_step()
         # Test step 2.b
         self.payload_rendezvous_capabilities_bit_mask_check(
-            qr_code_payload.rendezvousInfo, 15
+            qr_code_payload.rendezvousInfo
         )
         self.next_step()
         # Test step 2.c

--- a/onboarding_payload_test_suite/tcdd13/tcdd13.py
+++ b/onboarding_payload_test_suite/tcdd13/tcdd13.py
@@ -65,10 +65,6 @@ class TCDD13(PayloadParsingTestBaseClass):
             TestStep("""Step3.d: Verify the onboarding payload contains a 27-bit Passcode\
                      - Verify the 27-bit unsigned integer encodes an 8-digit decimal numeric value and shall be a value between 0x0000001 to 0x5f5e0fe (00000001 to 99999998)"""),
 
-            TestStep("""Step3.e: Verify passcode is valid\
-                     - Verify passcode does not use any trivial values: 00000000, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321\
-                     - Verify Passcode is not derived from public information as serial number, manufacturer date, MAC address, region of origin etc."""),
-
             TestStep("""Step3.f: Verify NFC's onboarding payload code prefix\
                      - Verify NFC's onboarding payload code prefix is "MT:"""),
 
@@ -96,44 +92,44 @@ class TCDD13(PayloadParsingTestBaseClass):
         nfc_code_payload = await self.chip_tool_parse_onboarding_code(prompt_response)
         logger.info(f"Parsed payload : {nfc_code_payload}")
 
-        self.next_step()
         # Test step 3.a
+        self.next_step()
         logger.info("Verifying the NFC's onboarding payload code version...")
         self.payload_version_check(nfc_code_payload.version)
-    
-        self.next_step()
+
         # Test step 3.b
+        self.next_step()
         logger.info("Verifying the 8-bit Discovery Capabilities bit mask...")
         self.payload_rendezvous_capabilities_bit_mask_check(
             nfc_code_payload.rendezvousInfo
         )
 
-        self.next_step()
         # Test step 3.c
+        self.next_step()
         logger.info("Verifying the 12-bit discriminator bit mask...")
         # TODO Extract discriminator from device advertises frame Issue#186
         await self.payload_discriminator_check(nfc_code_payload.discriminator)
 
-        self.next_step()
         # Test step 3.d
+        self.next_step()
         logger.info("Verifying the onboarding payload contains a 27-bit passcode...")
         self.payload_passcode_check(nfc_code_payload.setUpPINCode)
 
-        self.next_step()
         # Test step 3.f
-        logger.info("Verifying passcode is valid...")
+        self.next_step()
+        logger.info("Verifying NFC's onboarding payload code prefix...")
         nfc_code_prefix = prompt_response[:3]
         self.payload_prefix_check(nfc_code_prefix)
 
-        self.next_step()
         # Test step 3.g
+        self.next_step()
         logger.info("Verifying Vendor ID and Product ID...")
         self.vendorid_productid_check(
             nfc_code_payload.vendorID, nfc_code_payload.productID
         )
 
-        self.next_step()
         # Test step 5
+        self.next_step()
         logger.info("Verifying custom payload support...")
         self.custom_payload_support_check(nfc_code_payload.commissioningFlow)
 

--- a/onboarding_payload_test_suite/tcdd13/tcdd13.py
+++ b/onboarding_payload_test_suite/tcdd13/tcdd13.py
@@ -88,7 +88,7 @@ class TCDD13(PayloadParsingTestBaseClass):
         prompt_response = await self.invoke_prompt_and_get_str_response(prompt_request)
         logger.info(f"User input : {prompt_response}")
 
-        # Parsing the NFC oboarding code payload response
+        # Parsing the NFC onboarding code payload response
         nfc_code_payload = await self.chip_tool_parse_onboarding_code(prompt_response)
         logger.info(f"Parsed payload : {nfc_code_payload}")
 

--- a/onboarding_payload_test_suite/tcdd13/tcdd13.py
+++ b/onboarding_payload_test_suite/tcdd13/tcdd13.py
@@ -74,7 +74,7 @@ class TCDD13(PayloadParsingTestBaseClass):
         self.next_step()
         # Test step 3.b
         self.payload_rendezvous_capabilities_bit_mask_check(
-            nfc_code_payload.rendezvousInfo
+            nfc_code_payload.rendezvousInfo, 15
         )
         self.next_step()
         # Test step 3.c

--- a/onboarding_payload_test_suite/tcdd13/tcdd13.py
+++ b/onboarding_payload_test_suite/tcdd13/tcdd13.py
@@ -74,7 +74,7 @@ class TCDD13(PayloadParsingTestBaseClass):
         self.next_step()
         # Test step 3.b
         self.payload_rendezvous_capabilities_bit_mask_check(
-            nfc_code_payload.rendezvousInfo, 15
+            nfc_code_payload.rendezvousInfo
         )
         self.next_step()
         # Test step 3.c

--- a/onboarding_payload_test_suite/tcdd13/tcdd13.py
+++ b/onboarding_payload_test_suite/tcdd13/tcdd13.py
@@ -56,7 +56,8 @@ class TCDD13(PayloadParsingTestBaseClass):
                 - Bit 1 - BLE: - 0: Device does not support BLE for discovery or is currently commissioned into one or more fabrics. - 1: Device supports BLE for discovery when not commissioned.\
                 - Bit 2 - On IP network: - 1: Device is already on the IP network\
                 - Bits 3 - Wi-Fi Public Action Frame: - 0: Device does not support Wi-Fi Public Action Frame for discovery or is currently commissioned into one or more fabrics. - 1: Device supports Wi-Fi Public Action Frame for discovery when not commissioned.\
-                - Bits 7-4 - Reserved (SHALL be 0)\
+                - Bit 4 - NFC Transport Layer:  - 0: Device does not support NFC Transport Layer (NTL) for commissioning or is currently commissioned into one or more fabrics. - 1: Device supports NFC Transport Layer (NTL) for commissioning when not commissioned.\
+                - Bits 7-5 - Reserved (SHALL be 0)\
                 - Ensure that the bitmask accurately reflects the DUT’s supported commissioning methods and no reserved bits are set."""),
 
             TestStep("""Step3.c: Verify the 12-bit discriminator bit mask\

--- a/onboarding_payload_test_suite/tcdd13/tcdd13.py
+++ b/onboarding_payload_test_suite/tcdd13/tcdd13.py
@@ -24,10 +24,10 @@ class TCDD13(PayloadParsingTestBaseClass):
         "public_id": "TC-DD-1.3",
         "version": "0.0.1",
         "title": "TC-DD-1.3",
-        "description": """This test case verifies
-         that the onboarding NFC code contains the
-         necessary information to onboard the
-         device onto the CHIP network.""",
+        "description": """This test case verifies that
+        the NFC tag's onboarding payload contains the
+        necessary information to onboard the device
+        onto the Matter network.""",
     }
 
     @classmethod
@@ -45,55 +45,96 @@ class TCDD13(PayloadParsingTestBaseClass):
                 "Step1: Power up the DUT and put the DUT in pairing mode\
                      and bring the NFC code reader close to the DUT"
             ),
-            TestStep("Step3.a: Verify the NFC code payload version"),
-            TestStep("Step3.b: Verify 8-bit Rendezvous Capabilities bit mask"),
-            TestStep("Step3.c: Verify the 12-bit discriminator bit mask"),
-            TestStep(
-                "Step3.d: Verify the onboarding payload contains a 27-bit Passcode"
-            ),
-            TestStep("Step3.e: Verify passcode is valid"),
-            TestStep("Step3.f: Verify NFC code prefix"),
-            TestStep("Step3.g: Verify Vendor ID and Product ID"),
-            TestStep("Step5: Verify Custom payload support"),
+
+            TestStep("""Step3.a: Verify the NFC's onboarding payload code version\
+                     - Verify the NFC's onboarding payload code version is '000'"""),
+
+            TestStep("""Step3.b: Verify 8-bit Discovery Capabilities bit mask\
+                Verify that the onboarding payload contains an 8-bit Discovery Capabilities bitmask. Each bit must represent the following transport support:
+
+                - Bit 0 - Reserved (SHALL be 0)\
+                - Bit 1 - BLE: - 0: Device does not support BLE for discovery or is currently commissioned into one or more fabrics. - 1: Device supports BLE for discovery when not commissioned.\
+                - Bit 2 - On IP network: - 1: Device is already on the IP network\
+                - Bits 3 - Wi-Fi Public Action Frame: - 0: Device does not support Wi-Fi Public Action Frame for discovery or is currently commissioned into one or more fabrics. - 1: Device supports Wi-Fi Public Action Frame for discovery when not commissioned.\
+                - Bits 7-4 - Reserved (SHALL be 0)\
+                - Ensure that the bitmask accurately reflects the DUT’s supported commissioning methods and no reserved bits are set."""),
+
+            TestStep("""Step3.c: Verify the 12-bit discriminator bit mask\
+                     - Verify the 12-bit discriminator matches the value which a device advertises during commissioning."""),
+
+            TestStep("""Step3.d: Verify the onboarding payload contains a 27-bit Passcode\
+                     - Verify the 27-bit unsigned integer encodes an 8-digit decimal numeric value and shall be a value between 0x0000001 to 0x5f5e0fe (00000001 to 99999998)"""),
+
+            TestStep("""Step3.e: Verify passcode is valid\
+                     - Verify passcode does not use any trivial values: 00000000, 11111111, 22222222, 33333333, 44444444, 55555555, 66666666, 77777777, 88888888, 99999999, 12345678, 87654321\
+                     - Verify Passcode is not derived from public information as serial number, manufacturer date, MAC address, region of origin etc."""),
+
+            TestStep("""Step3.f: Verify NFC's onboarding payload code prefix\
+                     - Verify NFC's onboarding payload code prefix is "MT:"""),
+
+            TestStep("""Step3.g: Verify Vendor ID and Product ID\
+                     - Verify Vendor ID and Product ID match the values submitted by manufacturer in Distributed Compliance Ledger"""),
+
+            TestStep("""Step5: Verify Custom payload support\
+                     - Verify the custom payload is a 2 bit field and the Values supported are 0, 1 and 2."""),
         ]
 
     async def setup(self) -> None:
         logger.info("This is a test case setup")
 
     async def execute(self) -> None:
-        # Test step 1 and 2
-        # Fetch NFC code payload from UI/NFC code reader.
+        # Test step 1: Power up the DUT and put the DUT in pairing mode
+
+        # Test step 2: Bring the NFC code reader close to the DUT"
+
+        # Prompt user for the NFC code payload from UI/NFC code reader.
         prompt_request = self.create_onboarding_code_payload_prompt("NFC")
         prompt_response = await self.invoke_prompt_and_get_str_response(prompt_request)
         logger.info(f"User input : {prompt_response}")
+
+        # Parsing the NFC oboarding code payload response
         nfc_code_payload = await self.chip_tool_parse_onboarding_code(prompt_response)
-        logger.info(f"parsed payload : {nfc_code_payload}")
+        logger.info(f"Parsed payload : {nfc_code_payload}")
+
         self.next_step()
         # Test step 3.a
+        logger.info("Verifying the NFC's onboarding payload code version...")
         self.payload_version_check(nfc_code_payload.version)
+    
         self.next_step()
         # Test step 3.b
+        logger.info("Verifying the 8-bit Discovery Capabilities bit mask...")
         self.payload_rendezvous_capabilities_bit_mask_check(
             nfc_code_payload.rendezvousInfo
         )
+
         self.next_step()
         # Test step 3.c
+        logger.info("Verifying the 12-bit discriminator bit mask...")
         # TODO Extract discriminator from device advertises frame Issue#186
         await self.payload_discriminator_check(nfc_code_payload.discriminator)
+
         self.next_step()
         # Test step 3.d
+        logger.info("Verifying the onboarding payload contains a 27-bit passcode...")
         self.payload_passcode_check(nfc_code_payload.setUpPINCode)
+
         self.next_step()
         # Test step 3.f
+        logger.info("Verifying passcode is valid...")
         nfc_code_prefix = prompt_response[:3]
         self.payload_prefix_check(nfc_code_prefix)
+
         self.next_step()
         # Test step 3.g
+        logger.info("Verifying Vendor ID and Product ID...")
         self.vendorid_productid_check(
             nfc_code_payload.vendorID, nfc_code_payload.productID
         )
+
         self.next_step()
         # Test step 5
+        logger.info("Verifying custom payload support...")
         self.custom_payload_support_check(nfc_code_payload.commissioningFlow)
 
     async def cleanup(self) -> None:


### PR DESCRIPTION
Addresses:
[[CERT-TEST-FAILURE] [TC-DD-1.3] Python script should provide more descriptive steps for ATL representatives #37422](https://github.com/project-chip/connectedhomeip/issues/37422)

This is the current test plan for TC-DD-1.3
https://github.com/CHIP-Specifications/chip-test-plans/blob/master/src/devicediscovery.adoc#313-tc-dd-13-nfc-onboarding-payload-verification-dut---commissionee

Updates:
- In the Expected Outcome column of the test plan it contains several detailed verifications for each step, I added them to the script step labels
- Added "Verifying xxxx xxx..." logging to script steps
- Expectations for each step are contained in the enhanced test step labels
- Added comments where values are parsed

Notes:
- Also updated the wording as per the latest test plan
- Step 3.e and 4 in the script are skipped as per the original script even though they exist in the test plan, left them skipped (also removed step 3.e from the create_test_steps() function)

For any more clarification Sam Machin who made the first commit would be the go to person, but he's no longer at CSA, so someone with NFC flow knowledge would be the way to go.