### PR TITLE
Updating TCDD_12 Import For Backend's Change

### DIFF
--- a/onboarding_payload_test_suite/tcdd12/tcdd12.py
+++ b/onboarding_payload_test_suite/tcdd12/tcdd12.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023 Project CHIP Authors
+# Copyright (c) 2025 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -196,3 +196,4 @@ class TCDD12(PayloadParsingTestBaseClass):
             timeout=PROMPT_TIMEOUT,
         )
         return prompt_request
+


### PR DESCRIPTION
Updating TCDD_12 test case import to handle a change in the backend from the [PR#277](https://github.com/project-chip/certification-tool-backend/pull/277)