### PR TITLE
[Feature] Removing hardcoded prompt timeout

### DIFF
--- a/onboarding_payload_test_suite/onboarding_script_support.py
+++ b/onboarding_payload_test_suite/onboarding_script_support.py
@@ -21,7 +21,6 @@ from app.user_prompt_support.user_prompt_support import UserPromptSupport
 from ...sdk_tests.support.chip.chip_server import CHIP_TOOL_EXE
 from ...sdk_tests.support.sdk_container import SDKContainer
 
-PROMPT_TIMEOUT = 60
 SPL_STR = "[SPL] "
 
 
@@ -146,10 +145,7 @@ class PayloadParsingTestBaseClass(TestCase, UserPromptSupport, object):
             "prompt": f"Please enter the {code_type} code payload",
             "placeholder_text": "MT:YNJV75HZ00KA0648G00",
         }
-        prompt_request = TextInputPromptRequest(
-            **text_input_param,
-            timeout=PROMPT_TIMEOUT,
-        )
+        prompt_request = TextInputPromptRequest(**text_input_param)
         return prompt_request
 
     def create_discriminator_prompt(self) -> PromptRequest:
@@ -157,10 +153,7 @@ class PayloadParsingTestBaseClass(TestCase, UserPromptSupport, object):
             "prompt": "Please enter 12-bit discriminator from the device advertisement",
             "placeholder_text": "0xF00",
         }
-        prompt_request = TextInputPromptRequest(
-            **text_input_param,
-            timeout=PROMPT_TIMEOUT,
-        )
+        prompt_request = TextInputPromptRequest(**text_input_param)
         return prompt_request
 
     def payload_version_check(self, version: int) -> None:

--- a/onboarding_payload_test_suite/tcdd12/tcdd12.py
+++ b/onboarding_payload_test_suite/tcdd12/tcdd12.py
@@ -19,7 +19,6 @@ from app.test_engine.models import TestStep
 from app.user_prompt_support import PromptRequest, TextInputPromptRequest
 
 from ..onboarding_script_support import (
-    PROMPT_TIMEOUT,
     InvalidManualPairingCode,
     PayloadParsingTestBaseClass,
 )
@@ -191,8 +190,5 @@ class TCDD12(PayloadParsingTestBaseClass):
             "prompt": "Please enter the Manual pairing code",
             "placeholder_text": "34970112332",
         }
-        prompt_request = TextInputPromptRequest(
-            **text_input_param,
-            timeout=PROMPT_TIMEOUT,
-        )
+        prompt_request = TextInputPromptRequest(**text_input_param)
         return prompt_request

--- a/onboarding_payload_test_suite/tcdd14/tcdd14.py
+++ b/onboarding_payload_test_suite/tcdd14/tcdd14.py
@@ -84,10 +84,7 @@ class TCDD14(TestCase, UserPromptSupport):
             "prompt": "Please enter the concatenated QR code payload",
             "placeholder_text": "MT:YNJV75HZ00KA0648G00*W0GU2OTB00KA0648G00",
         }
-        prompt_request = TextInputPromptRequest(
-            **text_input_param,
-            timeout=60,
-        )
+        prompt_request = TextInputPromptRequest(**text_input_param)
         return prompt_request
 
     def _create_dut_count_prompt(self) -> PromptRequest:
@@ -95,8 +92,5 @@ class TCDD14(TestCase, UserPromptSupport):
             "prompt": "Please specify the number of devices that will be on-boarded.",
             "placeholder_text": "0x2",
         }
-        prompt_request = TextInputPromptRequest(
-            **text_input_param,
-            timeout=60,
-        )
+        prompt_request = TextInputPromptRequest(**text_input_param)
         return prompt_request


### PR DESCRIPTION
Fix: https://github.com/project-chip/certification-tool/issues/1038
Related to: https://github.com/project-chip/certification-tool-backend/pull/356
---

## Description
  Removes the redundant timeout=60 / PROMPT_TIMEOUT overrides in the onboarding QR/manual-pairing-code prompts. These duplicated the PromptRequest default with no distinct intent, so they now inherit the new project-configurable prompt timeout
  from certification-tool-backend (see that PR).

  Changed
  - onboarding_script_support.py: dropped PROMPT_TIMEOUT = 60 constant and its use.
  - tcdd12/tcdd12.py, tcdd14/tcdd14.py: dropped explicit timeout=60 kwargs.
  
  Test plan
  - No behavior change when the owning project has no th_config — same 60s default.
  - Covered indirectly by backend's test_python_test_case.py / prompt-support tests.