### PR TITLE
[TC-DD-1.3] Added Thread Commissioning Protocol verification in tcdd13.py and support script

### DIFF
--- a/onboarding_payload_test_suite/onboarding_script_support.py
+++ b/onboarding_payload_test_suite/onboarding_script_support.py
@@ -171,8 +171,9 @@ class PayloadParsingTestBaseClass(TestCase, UserPromptSupport, object):
         DISCOVERY_CAP_IP = 1 << 2
         DISCOVERY_CAP_PAF = 1 << 3
         DISCOVERY_CAP_NTL = 1 << 4
+        DISCOVERY_CAP_THREAD = 1 << 5
         ALL_CAPABILITIES_MASK = (
-            DISCOVERY_CAP_BLE | DISCOVERY_CAP_IP | DISCOVERY_CAP_PAF | DISCOVERY_CAP_NTL
+            DISCOVERY_CAP_BLE | DISCOVERY_CAP_IP | DISCOVERY_CAP_PAF | DISCOVERY_CAP_NTL | DISCOVERY_CAP_THREAD
         )
 
         if ((discovery_capabilities_bitmask & ~ALL_CAPABILITIES_MASK) != 0) or (

--- a/onboarding_payload_test_suite/tcdd11/tcdd11.py
+++ b/onboarding_payload_test_suite/tcdd11/tcdd11.py
@@ -59,9 +59,10 @@ class TCDD11(PayloadParsingTestBaseClass):
                      - Bit 0 - Reserved (SHALL be 0)
                      - Bit 1 - BLE: - 0: Device does not support BLE for discovery or is currently commissioned into one or more fabrics. - 1: Device supports BLE for discovery when not commissioned.
                      - Bit 2 - On IP network: - 1: Device is already on the IP network
-                     - Bits 3 - Wi-Fi Public Action Frame: - 0: Device does not support Wi-Fi Public Action Frame for discovery or is currently commissioned into one or more fabrics. - 1: Device supports Wi-Fi Public Action Frame for discovery when not commissioned.
-                     - Bits 4 - NFC Transport Layer - 0: Device does not support NFC Transport Layer (NTL) for commissioning or is currently commissioned into one or more fabrics. - 1: Device supports NFC Transport Layer (NTL) for commissioning when not commissioned.
-                     - Bits 7-5 - Reserved (SHALL be 0)
+                     - Bit 3 - Wi-Fi Public Action Frame: - 0: Device does not support Wi-Fi Public Action Frame for discovery or is currently commissioned into one or more fabrics. - 1: Device supports Wi-Fi Public Action Frame for discovery when not commissioned.
+                     - Bit 4 - NFC Transport Layer - 0: Device does not support NFC Transport Layer (NTL) for commissioning or is currently commissioned into one or more fabrics. - 1: Device supports NFC Transport Layer (NTL) for commissioning when not commissioned.
+                     - Bit 5 - Thread Commissioning Protocol: - 0: Device does not support Thread Commissioning Protocol for commissioning or is currently commissioned into one or more fabrics. - 1: Device supports Thread Commissioning Protocol for commissioning when not commissioned.
+                     - Bits 7-6 - Reserved (SHALL be 0)
                      - Ensure that the bitmask accurately reflects the DUT's supported commissioning methods and no reserved bits are set."""),
 
             TestStep("""Step2.e: Verify the 12-bit discriminator bit mask

--- a/onboarding_payload_test_suite/tcdd13/tcdd13.py
+++ b/onboarding_payload_test_suite/tcdd13/tcdd13.py
@@ -56,9 +56,10 @@ class TCDD13(PayloadParsingTestBaseClass):
                 - Bit 0 - Reserved (SHALL be 0)\
                 - Bit 1 - BLE: - 0: Device does not support BLE for discovery or is currently commissioned into one or more fabrics. - 1: Device supports BLE for discovery when not commissioned.\
                 - Bit 2 - On IP network: - 1: Device is already on the IP network\
-                - Bits 3 - Wi-Fi Public Action Frame: - 0: Device does not support Wi-Fi Public Action Frame for discovery or is currently commissioned into one or more fabrics. - 1: Device supports Wi-Fi Public Action Frame for discovery when not commissioned.\
+                - Bit 3 - Wi-Fi Public Action Frame: - 0: Device does not support Wi-Fi Public Action Frame for discovery or is currently commissioned into one or more fabrics. - 1: Device supports Wi-Fi Public Action Frame for discovery when not commissioned.\
                 - Bit 4 - NFC Transport Layer:  - 0: Device does not support NFC Transport Layer (NTL) for commissioning or is currently commissioned into one or more fabrics. - 1: Device supports NFC Transport Layer (NTL) for commissioning when not commissioned.\
-                - Bits 7-5 - Reserved (SHALL be 0)\
+                - Bit 5 - Thread Commissioning Protocol:  - 0: Device does not support Thread Commissioning Protocol for commissioning or is currently commissioned into one or more fabrics. - 1: Device supports Thread Commissioning Protocol for commissioning when not commissioned.\
+                - Bits 7-6 - Reserved (SHALL be 0)\
                 - Ensure that the bitmask accurately reflects the DUT’s supported commissioning methods and no reserved bits are set."""
             ),
             TestStep(


### PR DESCRIPTION
Added onboarding payload verification for Thread Commissioning Protocol in TC-DD-1.3 step 3.b.

Fix for https://github.com/CHIP-Specifications/chip-test-plans/issues/5940

Test Plan PR: https://github.com/CHIP-Specifications/chip-test-plans/pull/6401